### PR TITLE
fix: 카카오 로그인 및 인증 관련 로직 개선

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,21 +1,12 @@
-// <<<<<<< feat/teddy_0324
 // src/api/client.ts
 import axios from 'axios';
-import { getToken } from '../utils/authUtils';
-import { logout } from '../utils/authUtils';
+import { getToken, logout } from '../utils/authUtils';
+import { API_BASE_URL } from '../constants/api';
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://15.164.251.118:8080';
+// API_BASE_URL은 이제 constants/api.ts에서 가져옴
 
 const client = axios.create({
   baseURL: API_BASE_URL,
-  // =======
-  // import axios, { AxiosResponse, AxiosError, InternalAxiosRequestConfig } from 'axios';
-  // import { API_BACKEND_URL } from '../constants/api';
-
-  // // 기본 axios 인스턴스 생성
-  // export const client = axios.create({
-  //   baseURL: API_BACKEND_URL,
-  // >>>>>>> main
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,6 +1,8 @@
+// src/constants/api.ts
+
 // API 기본 URL 설정
 export const API_BACKEND_URL =
-  process.env.REACT_APP_API_BACKEND_URL || 'http://15.164.251.118:8080';
+  process.env.REACT_APP_API_BACKEND_URL || 'http://15.164.251.118:8080/';
 
 // API 경로 정의
 export const API_PATHS = {
@@ -59,12 +61,12 @@ export const API_PATHS = {
 };
 
 // API 기본 URL
-export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://15.164.251.118:8080';
+export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://15.164.251.118:8080/';
 
 // 카카오 인증 관련 상수
 export const KAKAO_AUTH = {
   REST_API_KEY: process.env.REACT_APP_KAKAO_REST_API_KEY || '244abed4cb1b567f33d22e14fc58a2c5',
-  REDIRECT_URI: 'http://localhost:3000/auth/kakao/callback',
+  REDIRECT_URI: process.env.REACT_APP_KAKAO_REDIRECT_URI || 'http://localhost:3000/auth/kakao',
   getLoginUrl: () => {
     return `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_AUTH.REST_API_KEY}&redirect_uri=${encodeURIComponent(KAKAO_AUTH.REDIRECT_URI)}&response_type=code`;
   },

--- a/src/pages/Login/KakaoCallback.tsx
+++ b/src/pages/Login/KakaoCallback.tsx
@@ -4,6 +4,9 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { kakaoLogin } from '../../api/auth';
 import { saveKakaoLoginData } from '../../utils/authUtils';
+// KAKAO_AUTH 상수에서 리다이렉트 URI를 가져오므로 여기서는 별도로 선언하지 않음
+// 카카오 로그인 관련 상수 가져오기
+import { KAKAO_AUTH } from '../../constants/api';
 
 // 로딩 컨테이너
 const LoadingContainer = styled.div`
@@ -98,13 +101,17 @@ const KakaoCallback: React.FC = () => {
           sessionStorage.setItem('processed_kakao_code', code);
 
           // 토큰 및 사용자 정보 저장
-          const { accessToken } = response.data;
+          const { accessToken, userId, nickname, role } = response.data;
 
           // 유틸리티 함수를 사용하여 로그인 데이터 저장
           saveKakaoLoginData({
             accessToken,
+            userId,
+            nickname,
+            role,
           });
-          console.log('로그인 정보 저장 완료:', localStorage.getItem('token'));
+
+          console.log('로그인 정보 저장 완료:', localStorage.getItem('accessToken'));
 
           // 메인 페이지로 리다이렉트 (토스트 메시지 표시 위한 상태 포함)
           console.log('홈으로 리다이렉트 시도...');

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,6 +1,10 @@
 // src/pages/Login/index.tsx
 import React from 'react';
 import styled from 'styled-components';
+import { KAKAO_AUTH } from '../../constants/api';
+// 환경 변수에서 직접 가져올 수도 있음
+// const KAKAO_REST_API_KEY = process.env.REACT_APP_KAKAO_REST_API_KEY;
+// const KAKAO_REDIRECT_URI = process.env.REACT_APP_KAKAO_REDIRECT_URI;
 
 // 스타일 컴포넌트들
 const PageContainer = styled.div`
@@ -107,14 +111,8 @@ const LogoImage = styled.div`
 const LoginPage: React.FC = () => {
   // 카카오 로그인 처리 함수
   const handleKakaoLogin = () => {
-    const KAKAO_REST_API_KEY =
-      process.env.REACT_APP_KAKAO_REST_API_KEY || '244abed4cb1b567f33d22e14fc58a2c5';
-
-    // 백엔드가 기대하는 리다이렉트 URI로 변경
-    const KAKAO_REDIRECT_URI = 'http://localhost:3000/auth/kakao';
-
-    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${encodeURIComponent(KAKAO_REDIRECT_URI)}&response_type=code&prompt=login`;
-
+    // 콘스탄트 파일에서 정의된 함수 사용
+    const kakaoAuthUrl = KAKAO_AUTH.getLoginUrl();
     console.log('카카오 로그인 시작:', kakaoAuthUrl);
     window.location.href = kakaoAuthUrl;
   };

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -14,14 +14,14 @@ const PrivateRoute: React.FC<PrivateRouteProps> = ({ requiredRole }) => {
   const { isAuthenticated, user, loading } = useAuth();
 
   // 인증 정보 로딩 중일 때 로딩 표시
-  // if (loading) {
-  //   return <div>로딩 중...</div>;
-  // }
+  if (loading) {
+    return <div>로딩 중...</div>;
+  }
 
   // 로그인하지 않은 경우 로그인 페이지로 리다이렉트
-  // if (!isAuthenticated) {
-  //   return <Navigate to="/login" replace />;
-  // }
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
 
   // 특정 역할이 요구되는 경우 역할 확인
   if (requiredRole && user?.role !== requiredRole) {

--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -6,8 +6,7 @@
 
 // 로컬 스토리지 키
 export const AUTH_KEYS = {
-  TOKEN: 'token',
-  REFRESH_TOKEN: 'refreshToken', // 리프레시 토큰 추가
+  TOKEN: 'accessToken', // accessToken으로 키 이름 수정
   USER_ID: 'userId',
   USER_NICKNAME: 'userNickname',
   USER_ROLE: 'userRole', // 사용자 역할 추가
@@ -25,9 +24,8 @@ export const saveUserId = (userId: string | number): void => {
  * 로컬 스토리지에서 사용자 ID 가져오기
  * @returns 사용자 ID 또는 null
  */
-export const getUserId = (): number | null => {
-  const userId = localStorage.getItem(AUTH_KEYS.USER_ID);
-  return userId ? parseInt(userId, 10) : null;
+export const getUserId = (): string | null => {
+  return localStorage.getItem(AUTH_KEYS.USER_ID);
 };
 
 /**
@@ -44,22 +42,6 @@ export const saveToken = (token: string): void => {
  */
 export const getToken = (): string | null => {
   return localStorage.getItem(AUTH_KEYS.TOKEN);
-};
-
-/**
- * 리프레시 토큰을 로컬 스토리지에 저장
- * @param refreshToken 리프레시 토큰
- */
-export const saveRefreshToken = (refreshToken: string): void => {
-  localStorage.setItem(AUTH_KEYS.REFRESH_TOKEN, refreshToken);
-};
-
-/**
- * 로컬 스토리지에서 리프레시 토큰 가져오기
- * @returns 리프레시 토큰 또는 null
- */
-export const getRefreshToken = (): string | null => {
-  return localStorage.getItem(AUTH_KEYS.REFRESH_TOKEN);
 };
 
 /**
@@ -98,8 +80,8 @@ export const getUserRole = (): string | null => {
  * 로그아웃 - 모든 인증 관련 데이터 삭제
  */
 export const logout = (): void => {
+  // RefreshToken은 쿠키에 있으므로 백엔드에서 처리해야 함
   localStorage.removeItem(AUTH_KEYS.TOKEN);
-  localStorage.removeItem(AUTH_KEYS.REFRESH_TOKEN);
   localStorage.removeItem(AUTH_KEYS.USER_ID);
   localStorage.removeItem(AUTH_KEYS.USER_NICKNAME);
   localStorage.removeItem(AUTH_KEYS.USER_ROLE);
@@ -138,16 +120,11 @@ export const getAuthHeaders = (): Record<string, string> => {
  */
 export const saveKakaoLoginData = (data: {
   accessToken: string;
-  refreshToken?: string;
   userId?: string | number;
   nickname?: string;
   role?: string;
 }): void => {
   saveToken(data.accessToken);
-
-  if (data.refreshToken) {
-    saveRefreshToken(data.refreshToken);
-  }
 
   if (data.userId) {
     saveUserId(data.userId);


### PR DESCRIPTION
### Description
<img width="1502" alt="스크린샷 2025-03-25 오전 12 41 42" src="https://github.com/user-attachments/assets/924a6f40-26c6-4cea-933d-d3cb75fe621e" />

1. 인증 검사 로직 개선
PrivateRoute의 인증 체크 로직을 활성화하여 비로그인 사용자는 로그인 페이지로 리다이렉트되도록 수정
로그인 상태 유지를 위한 로직 강화

2. 리프레시 토큰 관리 최적화
리프레시 토큰을 쿠키로만 관리하도록 수정 (로컬 스토리지에 중복 저장하지 않음)
로그아웃 시 로컬 스토리지의 관련 데이터만 제거

3. 코드 구조 개선
AuthUtils와 API 상수 파일 구조 정리
client.ts의 병합 충돌 해결
불필요한 빈 파일 정리

4.환경 변수 활용
하드코딩된 URL과 API 키를 환경 변수로 대체
일관된 리다이렉트 URI 사용

테스트 항목
- 로그인하지 않은 상태에서 비공개 페이지 접근 시 로그인 페이지로 리다이렉트
- 카카오 로그인 성공 후 토큰 저장 및 사용자 정보 표시
- 페이지 새로고침 후에도 로그인 상태 유지
- 로그아웃 시 인증 정보 제거 및 로그인 페이지로 리다이렉트