### PR TITLE
fix: KakaoMap 및 Home 페이지의 위치 처리 로직 개선

### DIFF
--- a/src/pages/Home/MapBottomSheet.tsx
+++ b/src/pages/Home/MapBottomSheet.tsx
@@ -454,21 +454,27 @@ const MapBottomSheet: React.FC<MapBottomSheetProps> = ({
     }
   };
 
-  // 이제 MapBottomSheet에서는 index.tsx에서 전달받은 값을 사용하므로,
-  // 현재 위치를 가져오는 별도의 useEffect는 제거합니다.
-  // (필요시 index.tsx에서 관리된 current location을 그대로 사용)
-
-  useEffect(() => {
-    if (propLocationInfoId !== locationInfoId) {
-      setLocationInfoId(propLocationInfoId ?? undefined);
-    }
-  }, [propLocationInfoId]);
-
   useEffect(() => {
     if (location !== currentLocation) {
       setCurrentLocation(location);
+
+      // 위치가 변경되었을 때 해당 위치의 데이터를 가져오기 위해
+      // locationInfoId가 없거나 위치 변경 시 fetchLocationId 호출
+      if (fetchLocationId && !propLocationInfoId) {
+        console.log('위치 변경으로 위치 ID 조회 시작:', location);
+        fetchLocationId(location)
+          .then(newLocationId => {
+            if (newLocationId) {
+              console.log('새로운 위치 ID 조회 완료:', newLocationId);
+              setLocationInfoId(newLocationId);
+            }
+          })
+          .catch(error => {
+            console.error('위치 ID 조회 중 오류:', error);
+          });
+      }
     }
-  }, [location, currentLocation]);
+  }, [location, currentLocation, fetchLocationId, propLocationInfoId]);
 
   useEffect(() => {
     const fetchRecentTrades = async () => {


### PR DESCRIPTION
### Description

1. KakaoMap 컴포넌트에 onZoomChanged 콜백을 추가하여 줌 레벨 변경 시 이벤트를 처리할 수 있도록 개선
2. 현재 위치를 가져오는 로직을 LocationService에서 Geolocation API를 사용하여 개선, 사용자 위치를 보다 정확하게 설정
3. Home 페이지에서 위치 정보 조회 로직을 개선하여, 기본 위치를 사용하도록 처리하고, 위치 ID 조회를 최적화
4. LocationSearchModal에서 주소를 간소화하여 저장 및 선택 시 사용자 경험을 향상
5. MapBottomSheet에서 위치 변경 시 위치 ID 조회 로직을 추가하여 데이터 일관성을 높임

### ✅현재까지 수정사항
1. **현재 초기 진입 시 사용하는 로직** 
    - 수정 전: 이전에 저장된 위치 정보를 조회하는 로직
    - 수정 후 : **현재 좌표 사용 → 좌표를 주소로 변환 → 해당 위치에 게시물을 로딩**
        - 현재 위치가 화면 상에 표시
2. **동네 수정**
    - 동네 수정 시 게시판 마커가 있는 위치로 이동
3. **게시판 마커**
    - 게시글 주소에 해당하는 위치에 마커 표시
    
    ※ 게시판을 불러오는 기준 : 
    
    - 현재 지정된 동네 단위로 마커를 찍음. → 동네 수정 or 현재 위치 버튼 클릭
    - 따라서 지도를 이동한다고 마커가 생기진 않습니다.

### Related Issues

### Changes Made
1. KakaoMap.tsx
2. LocationSearchModal.tsx
3. MapBottomSheet.tsx

### Screenshots or Video


### Testing


### Checklist
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes
