### PR TITLE
fix: 마이페이지에서 닉네임 변경 시 토큰 저장 로직 개선

### DIFF
--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -6,7 +6,7 @@ import BottomNavigation from '../../components/layout/BottomNavigation';
 import Modal from '../../components/common/Modal';
 import Toast from '../../components/common/Toast';
 import { useAuth } from '../../hooks/auth';
-import { logout } from '../../utils/api/authUtils';
+import { logout, saveToken } from '../../utils/api/authUtils';
 import KeeperRegistrationModal from '../../components/modals/KeeperRegisterationModal';
 import { useEffect } from 'react';
 import { isAuthenticated, isKeeper } from '../../utils/api/authUtils';
@@ -654,13 +654,14 @@ const MyPage: React.FC = () => {
       const response = await client.patch(API_PATHS.USER.NICKNAME, {
         nickname: trimmed,
       });
+      console.log('response.data.data', response.data.data.access_token);
 
-      if (response.data.accessToken) {
+      if (response.data.data.access_token) {
         // 로컬 스토리지의 accessToken 교체
-        localStorage.setItem('accessToken', response.data.accessToken);
+        saveToken(response.data.data.access_token);
 
         // 새로운 토큰 디코딩하여 사용자 정보 업데이트
-        const decoded = decodeToken(response.data.accessToken);
+        const decoded = decodeToken(response.data.data.access_token);
         if (decoded) {
           setUserState(prev => ({
             ...prev,


### PR DESCRIPTION
### Description

- `logout` 함수와 함께 `saveToken` 함수를 추가하여 새로운 access token을 로컬 스토리지에 저장하도록 수정
- API 응답에서 access token을 `response.data.data.access_token`으로 변경하여 올바른 토큰을 저장하도록 개선
- 사용자 정보 업데이트 시 디코딩된 토큰을 사용하여 상태를 업데이트하는 로직을 유지

### Related Issues


### Changes Made
1. index.tsx

### Testing


### Checklist
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes