### PR TITLE
fix: MyPlacePage와 MyTradePage 스타일 수정

### DIFF
--- a/src/pages/MyPage/subpages/MyPlacePage.tsx
+++ b/src/pages/MyPage/subpages/MyPlacePage.tsx
@@ -39,14 +39,14 @@ const Container = styled.div`
 
 // 장소 카드 스타일
 const PlaceCard = styled.div`
-  width: 326px;
-  height: 80px;
-  margin: 10px auto;
+  width: 90%;
+  height: 100px;
+  margin: 6px auto;
   background: rgba(217, 217, 217, 0);
   border-radius: 10px;
   border: 1px ${THEME.borderColor} solid;
   position: relative;
-  padding: 15px;
+  padding: 12px;
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -75,7 +75,7 @@ const PlaceTitle = styled.div`
   font-family: 'Noto Sans KR';
   font-weight: 700;
   letter-spacing: 0.02px;
-  margin-bottom: 5px;
+  margin-bottom: 3px;
 `;
 
 // 장소 주소
@@ -101,7 +101,7 @@ const VisibilityTag = styled.div<{ isPublic: boolean }>`
   font-size: 12px;
   font-family: 'Noto Sans KR';
   font-weight: 500;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
 `;
 
 // 화살표 아이콘

--- a/src/pages/MyPage/subpages/MyTradePage.tsx
+++ b/src/pages/MyPage/subpages/MyTradePage.tsx
@@ -55,8 +55,8 @@ const Title = styled.span`
 `;
 
 const TradeCard = styled.div`
-  width: 293px;
-  height: 95px;
+  width: 90%;
+  height: 120px;
   background: rgba(217, 217, 217, 0);
   border-radius: 10px;
   border: 1px #e0e0e0 solid;
@@ -65,6 +65,7 @@ const TradeCard = styled.div`
   position: relative;
   margin-left: auto;
   margin-right: auto;
+  cursor: default;
 `;
 
 const TradeTitle = styled.span`
@@ -205,10 +206,6 @@ const MyTrade: React.FC = () => {
     fetchTrades();
   }, [navigate]);
 
-  const handleTradeItemClick = (tradeId: number) => {
-    navigate(`/${ROUTES.MYPAGE}/${ROUTES.MYTRADE}/${tradeId}`);
-  };
-
   if (loading) {
     return (
       <Container>
@@ -229,7 +226,7 @@ const MyTrade: React.FC = () => {
     <Container>
       <div style={{ marginBottom: '20px' }}>
         {trades.map(trade => (
-          <TradeCard key={trade.trade_id} onClick={() => handleTradeItemClick(trade.trade_id)}>
+          <TradeCard key={trade.trade_id}>
             <div>
               <TradeStatus>{trade.keeper_status ? '맡아줬어요' : '보관했어요'}</TradeStatus>
               <div>


### PR DESCRIPTION
### Description
마이페이지의 보관소와 거래 내역 페이지의 UI 스타일을 개선했습니다. 

### Related Issues
- Resolves #56 #55

### Changes Made

1. MyPlacePage 카드 컴포넌트 스타일 수정
   - 카드 너비를 326px에서 90%로 변경하여 반응형 대응
   - 카드 높이를 80px에서 100px로 증가
   - 카드 간 마진을 8px에서 6px로 조정하여 더 조밀한 레이아웃 구성

2. MyTradePage 카드 컴포넌트 스타일 유지
   - 기존 90% 너비 유지
   - 120px 높이 유지
   - 일관된 디자인 시스템 적용


### Testing
1. 다양한 화면 크기에서 카드 레이아웃 테스트
   - 모바일 화면 (375px)
   - 태블릿 화면 (768px)
2. 카드 컴포넌트 간격 및 정렬 확인
3. 텍스트 가독성 및 레이아웃 밸런스 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

- 두 페이지의 카드 컴포넌트 스타일을 통일성 있게 조정했습니다.
- 반응형 디자인을 고려하여 픽셀 값 대신 상대적 단위(%)를 사용했습니다.
- 사용자 경험 향상을 위해 간격과 여백을 최적화했습니다.
