### PR TITLE
feat: 최근 거래 내역 API 통합 및 데이터 처리 개선

### DIFF
--- a/src/pages/Home/MapBottomSheet.tsx
+++ b/src/pages/Home/MapBottomSheet.tsx
@@ -393,10 +393,7 @@ const MapBottomSheet: React.FC<MapBottomSheetProps> = ({
   const navigate = useNavigate();
   const [showKeeperModal, setShowKeeperModal] = useState(false);
   const [sheetState, setSheetState] = useState<BottomSheetState>('half-expanded');
-  // 현재 위치 텍스트는 prop을 그대로 사용하거나, 필요시 내부 상태로 관리할 수 있음
   const [currentLocation, setCurrentLocation] = useState<string>(location);
-  // 최근 거래 내역은 내부에서 관리
-  const [recentTrades, setRecentTrades] = useState<RecentTrade[]>([]);
   const [locationInfoId, setLocationInfoId] = useState<number>(propLocationInfoId ?? -1);
 
   const bottomSheetRef = useRef<HTMLDivElement>(null);
@@ -465,7 +462,6 @@ const MapBottomSheet: React.FC<MapBottomSheetProps> = ({
     if (location !== currentLocation) {
       setCurrentLocation(location);
 
-      // 위치가 변경되었을 때 해당 위치의 데이터를 가져오기 위해
       // locationInfoId가 없거나 위치 변경 시 fetchLocationId 호출
       if (fetchLocationId && !propLocationInfoId) {
         console.log('위치 변경으로 위치 ID 조회 시작:', location);
@@ -482,30 +478,6 @@ const MapBottomSheet: React.FC<MapBottomSheetProps> = ({
       }
     }
   }, [location, currentLocation, fetchLocationId, propLocationInfoId]);
-
-  useEffect(() => {
-    const fetchRecentTrades = async () => {
-      try {
-        if (locationInfoId === -1) {
-          console.warn('locationInfoId가 -1이어서 최근 거래 내역을 가져올 수 없습니다.');
-          setRecentTrades([]);
-          return;
-        }
-
-        const response = await getRecentTrades(locationInfoId);
-        if (response.success && Array.isArray(response.data)) {
-          setRecentTrades(response.data);
-        } else {
-          console.warn('거래 내역 응답 형식 오류:', response);
-          setRecentTrades([]);
-        }
-      } catch (error) {
-        console.error('최근 거래 내역 가져오기 실패:', error);
-        setRecentTrades([]);
-      }
-    };
-    fetchRecentTrades();
-  }, [locationInfoId]);
 
   const handleRegisterClick = () => {
     if (onRegisterStorage) {
@@ -665,25 +637,21 @@ const MapBottomSheet: React.FC<MapBottomSheetProps> = ({
           </DiscountGrid>
           <SectionTitle>{currentLocation.split(' ')[1]} 최근 거래 내역</SectionTitle>
           <ItemList>
-            {recentTrades.length > 0 ? (
-              recentTrades.map((trade, index) => (
+            {recentItems.length > 0 ? (
+              recentItems.map((trade, index) => (
                 <ItemCard key={index}>
                   <ItemImage
                     style={{
-                      backgroundImage: trade.main_image ? `url(${trade.main_image})` : 'none',
+                      backgroundImage: trade.imageUrl ? `url(${trade.imageUrl})` : 'none',
                     }}
                   />
                   <ItemInfo>
-                    <ItemName>{trade.product_name}</ItemName>
+                    <ItemName>{trade.name}</ItemName>
                     <ItemPrice>
-                      <PriceText>
-                        {trade.trade_price ? trade.trade_price.toLocaleString() : '-'}원
-                      </PriceText>
+                      <PriceText>{trade.price ? trade.price.toLocaleString() : '-'}원</PriceText>
                       <PriceUnit> /일</PriceUnit>
                     </ItemPrice>
-                    <ItemTags>
-                      {trade.category} | {trade.storage_period}일
-                    </ItemTags>
+                    <ItemTags>{trade.post_tags.join(' | ')}</ItemTags>
                   </ItemInfo>
                 </ItemCard>
               ))

--- a/src/services/api/modules/trades.ts
+++ b/src/services/api/modules/trades.ts
@@ -43,12 +43,12 @@ export interface MyTradesResponse {
 
 // 최근 거래 내역 인터페이스
 export interface RecentTrade {
-  category: string;
   main_image: string;
   product_name: string;
-  storage_period: number;
+  category: string;
   trade_date: string;
   trade_price: number;
+  storage_period: number;
 }
 
 export interface RecentTradesResponse {
@@ -119,10 +119,21 @@ export const getMyTrades = async (): Promise<TradeItem[]> => {
  */
 export const getRecentTrades = async (locationInfoId: number): Promise<RecentTradesResponse> => {
   try {
+    if (!locationInfoId || locationInfoId === -1) {
+      console.warn('유효하지 않은 locationInfoId:', locationInfoId);
+      return {
+        success: false,
+        message: 'Invalid locationInfoId',
+        data: [],
+      };
+    }
+
     console.log('getRecentTrades 호출 - locationInfoId:', locationInfoId);
     const response = await client.get(API_PATHS.TRADES.RECENT_BY_LOCATION, {
       params: { locationInfoId },
     });
+    console.log('API 요청 URL:', API_PATHS.TRADES.RECENT_BY_LOCATION);
+    console.log('API 요청 파라미터:', { locationInfoId });
     console.log('API 응답 데이터:', response.data);
     return response.data;
   } catch (error) {


### PR DESCRIPTION
### Description

- HomePage 컴포넌트에서 최근 거래 내역을 가져오는 API 호출을 `getRecentTrades`로 변경하여 코드 일관성을 높임.
- 거래 내역 응답 형식 검증을 추가하여 오류 처리 개선.
- MapBottomSheet 컴포넌트에서 최근 거래 내역 관련 상태 및 로직을 제거하여 코드 간소화.
- 거래 데이터의 필드 이름을 API 응답에 맞게 수정하여 데이터 매핑을 개선.
- 최근 거래 내역을 표시하는 UI에서 데이터 구조 변경에 따른 수정 적용.

### Related Issues


### Changes Made
1. MapBottomSheet
2. trade
3. Home/index

### Screenshots or Video


### Testing
1. [테스트 1]
2. [테스트 2]
4. [테스트 3]

### Checklist
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
